### PR TITLE
Babashka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.iml
 *.mutation-backup
 .claude/
 .cpcache/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-target/
-.cpcache/
 *.mutation-backup
 .claude/
+.cpcache/
+.idea/
 docs/
+target/

--- a/SKILL.md
+++ b/SKILL.md
@@ -31,7 +31,7 @@ Optional coverage integration (skips mutations on uncovered lines):
 ```clojure
 :cov {:main-opts ["-m" "speclj.cloverage" "--" "-p" "src" "-s" "spec" "--lcov"]
       :extra-deps {cloverage/cloverage {:mvn/version "1.2.4"}
-                   speclj/speclj {:mvn/version "3.12.1"}}
+                   speclj/speclj {:mvn/version "3.12.2"}}
       :extra-paths ["spec"]}
 ```
 
@@ -43,16 +43,16 @@ Add `mutate` and `spec` tasks to your project's `bb.edn`:
 {:paths ["src" "spec"]
  :deps {clj-mutate/clj-mutate {:local/root "/path/to/clj-mutate"}
         org.clojure/tools.reader {:mvn/version "1.4.2"}
-        speclj/speclj {:mvn/version "3.12.1"}}
+        speclj/speclj {:mvn/version "3.12.2"}}
  :tasks {spec {:doc "Run all specs"
-               :requires ([speclj.cli :as speclj])
-               :task (System/exit (speclj/run "-c"))}
+               :requires ([speclj.main :as speclj])
+               :task (speclj/-main "-c")}
          mutate {:doc "Run mutation testing"
                  :requires ([clj-mutate.core :as mutate])
                  :task (apply mutate/-main *command-line-args*)}}}
 ```
 
-**Important: the `spec` task must propagate the exit code.** clj-mutate detects killed mutants by checking whether `bb spec` exits non-zero. Babashka's task runner intercepts `System/exit` calls from libraries, so `speclj.main/-main` (which calls `System/exit` internally) will NOT propagate the failure exit code — bb always exits 0. The fix is to call `speclj.cli/run` (which returns the failure count as an integer) and pass it to `System/exit` explicitly.
+**Important: use speclj 3.12.2+.** clj-mutate detects killed mutants by checking whether `bb spec` exits non-zero. Speclj 3.12.2 correctly propagates exit codes under babashka via `{:babashka/exit N}`. Earlier versions call `System/exit` which bb's task runner intercepts, causing bb to always exit 0 — making all mutants appear to survive.
 
 Requires a `spec` task that runs all specs. Cloverage is not available under babashka; coverage-guided filtering is skipped (all lines are mutation-tested). If an `lcov.info` file is present from an external source, it will be used.
 
@@ -124,4 +124,4 @@ Known-equivalent mutations are auto-suppressed to reduce false survivors:
 - **Specs fail at baseline**: Fix your specs before mutation testing
 - **Chasing equivalent mutations**: Some survivors are mathematically equivalent; suppress them rather than writing impossible tests
 - **Missing coverage in bb projects**: Cloverage is JVM-only. Babashka projects test all lines by default, which is slower but thorough
-- **All mutants survive in bb projects**: The `spec` task must call `(System/exit (speclj.cli/run "-c"))`, not `(speclj.main/-main "-c")`. Babashka intercepts `System/exit` from library code, so `-main`'s internal exit call is swallowed and bb always exits 0. clj-mutate relies on exit codes to detect killed mutants.
+- **All mutants survive in bb projects**: Requires speclj 3.12.2+ which propagates exit codes correctly under babashka. Earlier versions always exit 0 regardless of failures, so clj-mutate can't detect killed mutants.

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,6 +11,10 @@ Mutation testing for Clojure. Mutates source code systematically, runs your spec
 
 ## Setup
 
+clj-mutate auto-detects whether your project uses `bb.edn` (babashka) or `deps.edn` (JVM Clojure) and adjusts its spec runner and worker setup accordingly.
+
+### deps.edn projects
+
 Add a `:mutate` alias to your project's `deps.edn`:
 
 ```clojure
@@ -27,26 +31,50 @@ Optional coverage integration (skips mutations on uncovered lines):
 ```clojure
 :cov {:main-opts ["-m" "speclj.cloverage" "--" "-p" "src" "-s" "spec" "--lcov"]
       :extra-deps {cloverage/cloverage {:mvn/version "1.2.4"}
-                   speclj/speclj {:mvn/version "3.10.0"}}
+                   speclj/speclj {:mvn/version "3.12.1"}}
       :extra-paths ["spec"]}
 ```
+
+### bb.edn projects
+
+Add `mutate` and `spec` tasks to your project's `bb.edn`:
+
+```clojure
+{:paths ["src" "spec"]
+ :deps {clj-mutate/clj-mutate {:local/root "/path/to/clj-mutate"}
+        org.clojure/tools.reader {:mvn/version "1.4.2"}
+        speclj/speclj {:mvn/version "3.12.1"}}
+ :tasks {spec {:doc "Run all specs"
+               :task (exec 'speclj.main)
+               :exec-args ["-c"]}
+         mutate {:doc "Run mutation testing"
+                 :task (apply clojure.core/-main
+                              (exec 'clj-mutate.core)
+                              *command-line-args*)}}}
+```
+
+Requires a `spec` task that runs all specs. Cloverage is not available under babashka; coverage-guided filtering is skipped (all lines are mutation-tested). If an `lcov.info` file is present from an external source, it will be used.
 
 ## Usage
 
 ```bash
-# Mutation-test a source file (all covered lines)
+# deps.edn projects
 clj -M:mutate src/myapp/foo.cljc
-
-# Retest only specific lines (e.g. survivors from previous run)
 clj -M:mutate src/myapp/foo.cljc --lines 45,67,89
+
+# bb.edn projects
+bb mutate src/myapp/foo.cljc
+bb mutate src/myapp/foo.cljc --lines 45,67,89
 ```
 
 The tool automatically:
-- Runs a baseline test (`clj -M:spec`) to verify all specs pass unmodified
+- Detects project type (`bb.edn` or `deps.edn`) and uses the appropriate spec runner
+- Runs a baseline test to verify all specs pass unmodified
 - Applies each mutation, runs all specs with timeout (10x baseline)
 - Restores original file after each mutation
 - Stamps source with `;; mutation-tested: YYYY-MM-DD` on full runs
-- Runs coverage if `lcov.info` is missing or stale
+- For deps.edn projects: runs coverage if `lcov.info` is missing or stale
+- For bb.edn projects: uses existing `lcov.info` if present, otherwise tests all lines
 
 ## Mutation Rules
 
@@ -79,14 +107,19 @@ Known-equivalent mutations are auto-suppressed to reduce false survivors:
 ## Workflow
 
 1. Write specs using BDD/TDD
-2. Run `clj -M:mutate src/myapp/foo.cljc`
+2. Run mutation testing:
+   - deps.edn: `clj -M:mutate src/myapp/foo.cljc`
+   - bb.edn: `bb mutate src/myapp/foo.cljc`
 3. Review survivors -- each is a test gap
 4. Write specs to kill survivors
-5. Retest survivors: `clj -M:mutate src/myapp/foo.cljc --lines 45,67`
+5. Retest survivors:
+   - deps.edn: `clj -M:mutate src/myapp/foo.cljc --lines 45,67`
+   - bb.edn: `bb mutate src/myapp/foo.cljc --lines 45,67`
 6. Repeat until kill rate is satisfactory
 
 ## Common Mistakes
 
-- **Specs not running**: Ensure your `:spec` alias runs all specs under `spec/`
+- **Specs not running**: Ensure your `:spec` alias (deps.edn) or `spec` task (bb.edn) runs all specs under `spec/`
 - **Specs fail at baseline**: Fix your specs before mutation testing
 - **Chasing equivalent mutations**: Some survivors are mathematically equivalent; suppress them rather than writing impossible tests
+- **Missing coverage in bb projects**: Cloverage is JVM-only. Babashka projects test all lines by default, which is slower but thorough

--- a/SKILL.md
+++ b/SKILL.md
@@ -45,13 +45,14 @@ Add `mutate` and `spec` tasks to your project's `bb.edn`:
         org.clojure/tools.reader {:mvn/version "1.4.2"}
         speclj/speclj {:mvn/version "3.12.1"}}
  :tasks {spec {:doc "Run all specs"
-               :task (exec 'speclj.main)
-               :exec-args ["-c"]}
+               :requires ([speclj.cli :as speclj])
+               :task (System/exit (speclj/run "-c"))}
          mutate {:doc "Run mutation testing"
-                 :task (apply clojure.core/-main
-                              (exec 'clj-mutate.core)
-                              *command-line-args*)}}}
+                 :requires ([clj-mutate.core :as mutate])
+                 :task (apply mutate/-main *command-line-args*)}}}
 ```
+
+**Important: the `spec` task must propagate the exit code.** clj-mutate detects killed mutants by checking whether `bb spec` exits non-zero. Babashka's task runner intercepts `System/exit` calls from libraries, so `speclj.main/-main` (which calls `System/exit` internally) will NOT propagate the failure exit code — bb always exits 0. The fix is to call `speclj.cli/run` (which returns the failure count as an integer) and pass it to `System/exit` explicitly.
 
 Requires a `spec` task that runs all specs. Cloverage is not available under babashka; coverage-guided filtering is skipped (all lines are mutation-tested). If an `lcov.info` file is present from an external source, it will be used.
 
@@ -123,3 +124,4 @@ Known-equivalent mutations are auto-suppressed to reduce false survivors:
 - **Specs fail at baseline**: Fix your specs before mutation testing
 - **Chasing equivalent mutations**: Some survivors are mathematically equivalent; suppress them rather than writing impossible tests
 - **Missing coverage in bb projects**: Cloverage is JVM-only. Babashka projects test all lines by default, which is slower but thorough
+- **All mutants survive in bb projects**: The `spec` task must call `(System/exit (speclj.cli/run "-c"))`, not `(speclj.main/-main "-c")`. Babashka intercepts `System/exit` from library code, so `-main`'s internal exit call is swallowed and bb always exits 0. clj-mutate relies on exit codes to detect killed mutants.

--- a/bb.edn
+++ b/bb.edn
@@ -1,9 +1,9 @@
 {:paths ["src" "spec"]
  :deps {org.clojure/tools.reader {:mvn/version "1.4.2"}
-        speclj/speclj {:mvn/version "3.12.1"}}
+        speclj/speclj {:mvn/version "3.12.2"}}
  :tasks {spec {:doc "Run specs"
-               :requires ([speclj.cli :as speclj])
-               :task (System/exit (speclj/run "-c"))}
+               :requires ([speclj.main :as speclj])
+               :task (speclj/-main "-c")}
          mutate {:doc "Run mutation testing"
                  :requires ([clj-mutate.core :as mutate])
                  :task (apply mutate/-main *command-line-args*)}}}

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,8 @@
+{:paths ["src" "spec"]
+ :deps {org.clojure/tools.reader {:mvn/version "1.4.2"}
+        speclj/speclj {:mvn/version "3.12.1"}}
+ :tasks {spec {:doc "Run specs"
+               :task (do (require 'speclj.main)
+                         ((resolve 'speclj.main/-main) "-c"))}
+         mutate {:doc "Run mutation testing"
+                 :task (apply (requiring-resolve 'clj-mutate.core/-main) *command-line-args*)}}}

--- a/bb.edn
+++ b/bb.edn
@@ -2,7 +2,8 @@
  :deps {org.clojure/tools.reader {:mvn/version "1.4.2"}
         speclj/speclj {:mvn/version "3.12.1"}}
  :tasks {spec {:doc "Run specs"
-               :task (do (require 'speclj.main)
-                         ((resolve 'speclj.main/-main) "-c"))}
+               :requires ([speclj.cli :as speclj])
+               :task (System/exit (speclj/run "-c"))}
          mutate {:doc "Run mutation testing"
-                 :task (apply (requiring-resolve 'clj-mutate.core/-main) *command-line-args*)}}}
+                 :requires ([clj-mutate.core :as mutate])
+                 :task (apply mutate/-main *command-line-args*)}}}

--- a/deps.edn
+++ b/deps.edn
@@ -2,12 +2,12 @@
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
         org.clojure/tools.reader {:mvn/version "1.4.2"}}
  :aliases {:spec {:main-opts ["-m" "speclj.main" "-c"]
-                  :extra-deps {speclj/speclj {:mvn/version "3.10.0"}}
+                  :extra-deps {speclj/speclj {:mvn/version "3.12.1"}}
                   :extra-paths ["spec"]}
            :mutate {:main-opts ["-m" "clj-mutate.core"]
-                    :extra-deps {speclj/speclj {:mvn/version "3.10.0"}}
+                    :extra-deps {speclj/speclj {:mvn/version "3.12.1"}}
                     :extra-paths ["spec"]}
            :cov {:main-opts ["-m" "speclj.cloverage" "--" "-p" "src" "-s" "spec" "--lcov"]
                  :extra-deps {cloverage/cloverage {:mvn/version "1.2.4"}
-                              speclj/speclj {:mvn/version "3.10.0"}}
+                              speclj/speclj {:mvn/version "3.12.1"}}
                  :extra-paths ["spec"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -2,12 +2,12 @@
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
         org.clojure/tools.reader {:mvn/version "1.4.2"}}
  :aliases {:spec {:main-opts ["-m" "speclj.main" "-c"]
-                  :extra-deps {speclj/speclj {:mvn/version "3.12.1"}}
+                  :extra-deps {speclj/speclj {:mvn/version "3.12.2"}}
                   :extra-paths ["spec"]}
            :mutate {:main-opts ["-m" "clj-mutate.core"]
-                    :extra-deps {speclj/speclj {:mvn/version "3.12.1"}}
+                    :extra-deps {speclj/speclj {:mvn/version "3.12.2"}}
                     :extra-paths ["spec"]}
            :cov {:main-opts ["-m" "speclj.cloverage" "--" "-p" "src" "-s" "spec" "--lcov"]
                  :extra-deps {cloverage/cloverage {:mvn/version "1.2.4"}
-                              speclj/speclj {:mvn/version "3.12.1"}}
+                              speclj/speclj {:mvn/version "3.12.2"}}
                  :extra-paths ["spec"]}}}

--- a/spec/clj_mutate/core_spec.clj
+++ b/spec/clj_mutate/core_spec.clj
@@ -179,7 +179,7 @@
                       (doall (map (fn [site]
                                     (core/mutate-and-test source-path content nil site timeout-ms))
                                   sites)))]
-        (core/run-mutation-testing temp-path)
+        (with-out-str (core/run-mutation-testing temp-path))
         (let [stamped (slurp temp-path)]
           (should-not-be-nil (core/extract-mutation-date stamped))))
       (.delete temp-file)))
@@ -266,15 +266,15 @@
     (let [content (slurp "src/clj_mutate/mutations.cljc")
           forms (core/read-source-forms content)
           sites (core/discover-all-mutations forms)]
-      (should (> (count sites) 0))
-      (println (format "Found %d mutation sites in mutations.cljc" (count sites))))))
+      (should (> (count sites) 0)))))
 
 (describe "run-mutations-parallel"
   (it "tests all mutations and returns results sorted by index"
     (let [sites [{:index 0 :original '+ :mutant '- :line 5 :description "+ -> -"}
                  {:index 1 :original '> :mutant '>= :line 7 :description "> -> >="}
                  {:index 2 :original '= :mutant 'not= :line 9 :description "= -> not="}]
-          call-count (atom 0)]
+          call-count (atom 0)
+          results (atom nil)]
       (with-redefs [core/mutate-and-test-in-dir
                     (fn [_ _ _ site _]
                       (swap! call-count inc)
@@ -286,19 +286,19 @@
                       (should= "target/mutation-workers/run-test" base)
                       (vec (repeat n "target/fake-worker")))
                     workers/cleanup-worker-dirs! (fn [_] nil)]
-        (let [results (core/run-mutations-parallel
-                        sites "src/foo.cljc" "(ns foo)" 30000)]
-          (should= 3 (count results))
-          (should= 3 @call-count)
-          ;; Results sorted by index
-          (should= [0 1 2] (mapv #(:index (:site %)) results))
-          ;; All killed
-          (should (every? #(= :killed (:result %)) results))))))
+        (with-out-str
+          (reset! results (core/run-mutations-parallel
+                            sites "src/foo.cljc" "(ns foo)" 30000))))
+      (should= 3 (count @results))
+      (should= 3 @call-count)
+      (should= [0 1 2] (mapv #(:index (:site %)) @results))
+      (should (every? #(= :killed (:result %)) @results))))
 
   (it "works with more mutations than workers"
     (let [sites (vec (for [i (range 10)]
                        {:index i :original '+ :mutant '- :line (+ 5 i)
-                        :description (str "mut-" i)}))]
+                        :description (str "mut-" i)}))
+          results (atom nil)]
       (with-redefs [core/mutate-and-test-in-dir
                     (fn [_ _ _ site _]
                       {:site site :result :killed :timeout? false})
@@ -309,9 +309,10 @@
                       (should= "target/mutation-workers/run-test" base)
                       (vec (repeat n "target/fake-worker")))
                     workers/cleanup-worker-dirs! (fn [_] nil)]
-        (let [results (core/run-mutations-parallel
-                        sites "src/foo.cljc" "(ns foo)" 30000)]
-          (should= 10 (count results))
-          (should= (vec (range 10)) (mapv #(:index (:site %)) results)))))))
+        (with-out-str
+          (reset! results (core/run-mutations-parallel
+                            sites "src/foo.cljc" "(ns foo)" 30000))))
+      (should= 10 (count @results))
+      (should= (vec (range 10)) (mapv #(:index (:site %)) @results)))))
 
 (run-specs)

--- a/spec/clj_mutate/coverage_spec.clj
+++ b/spec/clj_mutate/coverage_spec.clj
@@ -64,7 +64,8 @@
       (with-redefs [cov/run-coverage! (fn [] (reset! ran? true)
                                         (spit temp-lcov sample-lcov)
                                         true)
-                    cov/lcov-path (constantly temp-lcov)]
+                    cov/lcov-path (constantly temp-lcov)
+                    clj-mutate.project/bb-project? (constantly false)]
         (java.nio.file.Files/deleteIfExists
           (.toPath (java.io.File. temp-lcov)))
         (with-out-str (reset! result (cov/load-coverage "src/empire/combat.cljc")))

--- a/spec/clj_mutate/coverage_spec.clj
+++ b/spec/clj_mutate/coverage_spec.clj
@@ -59,6 +59,7 @@
 (describe "load-coverage"
   (it "runs coverage when lcov.info is missing"
     (let [ran? (atom false)
+          result (atom nil)
           temp-lcov (str "/tmp/test-lcov-" (System/nanoTime) ".info")]
       (with-redefs [cov/run-coverage! (fn [] (reset! ran? true)
                                         (spit temp-lcov sample-lcov)
@@ -66,17 +67,18 @@
                     cov/lcov-path (constantly temp-lcov)]
         (java.nio.file.Files/deleteIfExists
           (.toPath (java.io.File. temp-lcov)))
-        (let [result (cov/load-coverage "src/empire/combat.cljc")]
-          (should @ran?)
-          (should= #{1 3 5} result)))))
+        (with-out-str (reset! result (cov/load-coverage "src/empire/combat.cljc")))
+        (should @ran?)
+        (should= #{1 3 5} @result))))
 
   (it "returns nil when lcov.info does not exist and coverage fails"
-    (let [temp-lcov (str "/tmp/nonexistent-lcov-" (System/nanoTime) ".info")]
+    (let [result (atom nil)
+          temp-lcov (str "/tmp/nonexistent-lcov-" (System/nanoTime) ".info")]
       (with-redefs [cov/run-coverage! (fn [] false)
                     cov/lcov-path (constantly temp-lcov)]
         (java.nio.file.Files/deleteIfExists
           (.toPath (java.io.File. temp-lcov)))
-        (should-be-nil (cov/load-coverage "src/empire/combat.cljc")))))
-  )
+        (with-out-str (reset! result (cov/load-coverage "src/empire/combat.cljc")))
+        (should-be-nil @result)))))
 
 (run-specs)

--- a/spec/clj_mutate/project_spec.clj
+++ b/spec/clj_mutate/project_spec.clj
@@ -1,0 +1,63 @@
+(ns clj-mutate.project-spec
+  (:require [speclj.core :refer :all]
+            [clj-mutate.project :as project])
+  (:import [java.io File]))
+
+(describe "bb-project?"
+  (it "returns true when bb.edn exists in the directory"
+    (let [dir (str "target/test-project-bb-" (System/nanoTime))]
+      (.mkdirs (File. dir))
+      (try
+        (spit (str dir "/bb.edn") "{}")
+        (should (project/bb-project? dir))
+        (finally
+          (.delete (File. (str dir "/bb.edn")))
+          (.delete (File. dir))))))
+
+  (it "returns false when bb.edn does not exist"
+    (let [dir (str "target/test-project-clj-" (System/nanoTime))]
+      (.mkdirs (File. dir))
+      (try
+        (should-not (project/bb-project? dir))
+        (finally
+          (.delete (File. dir)))))))
+
+(describe "spec-command"
+  (it "returns bb spec for bb projects"
+    (let [dir (str "target/test-project-cmd-" (System/nanoTime))]
+      (.mkdirs (File. dir))
+      (try
+        (spit (str dir "/bb.edn") "{}")
+        (should= ["bb" "spec"] (project/spec-command dir))
+        (finally
+          (.delete (File. (str dir "/bb.edn")))
+          (.delete (File. dir))))))
+
+  (it "returns clj -M:spec for deps.edn projects"
+    (let [dir (str "target/test-project-cmd2-" (System/nanoTime))]
+      (.mkdirs (File. dir))
+      (try
+        (should= ["clj" "-M:spec"] (project/spec-command dir))
+        (finally
+          (.delete (File. dir)))))))
+
+(describe "config-file"
+  (it "returns bb.edn for bb projects"
+    (let [dir (str "target/test-project-cfg-" (System/nanoTime))]
+      (.mkdirs (File. dir))
+      (try
+        (spit (str dir "/bb.edn") "{}")
+        (should= "bb.edn" (project/config-file dir))
+        (finally
+          (.delete (File. (str dir "/bb.edn")))
+          (.delete (File. dir))))))
+
+  (it "returns deps.edn for deps.edn projects"
+    (let [dir (str "target/test-project-cfg2-" (System/nanoTime))]
+      (.mkdirs (File. dir))
+      (try
+        (should= "deps.edn" (project/config-file dir))
+        (finally
+          (.delete (File. dir)))))))
+
+(run-specs)

--- a/spec/clj_mutate/workers_spec.clj
+++ b/spec/clj_mutate/workers_spec.clj
@@ -53,7 +53,31 @@
               (should (Files/isSymbolicLink (.toPath cp-link)))
               (should-not (.exists cp-link))))
           (finally
-            (workers/cleanup-worker-dirs! base-dir)))))))
+            (workers/cleanup-worker-dirs! base-dir))))))
+
+  (it "creates source overlay with symlinked siblings"
+    (let [base-dir "target/test-workers-overlay"
+          source-rel "src/clj_mutate/core.cljc"
+          content "(ns clj-mutate.core)\n"
+          dirs (workers/create-worker-dirs! base-dir source-rel content 1)]
+      (try
+        (let [dir (first dirs)
+              src-dir (File. (str dir "/src"))]
+          ;; src/ should be a real directory, not a symlink
+          (should (.isDirectory src-dir))
+          (should-not (Files/isSymbolicLink (.toPath src-dir)))
+          ;; The mutated file should be a real file
+          (should (.isFile (File. (str dir "/" source-rel))))
+          (should-not (Files/isSymbolicLink (.toPath (File. (str dir "/" source-rel)))))
+          (should= content (slurp (str dir "/" source-rel)))
+          ;; Sibling source files should be symlinks
+          (let [siblings (.listFiles (File. (str dir "/src/clj_mutate")))
+                non-mutated (filter #(not= "core.cljc" (.getName %)) siblings)]
+            (should (pos? (count non-mutated)))
+            (doseq [s non-mutated]
+              (should (Files/isSymbolicLink (.toPath s))))))
+        (finally
+          (workers/cleanup-worker-dirs! base-dir))))))
 
 (describe "cleanup-worker-dirs!"
   (it "removes the base directory and all contents"

--- a/spec/clj_mutate/workers_spec.clj
+++ b/spec/clj_mutate/workers_spec.clj
@@ -23,8 +23,10 @@
         (should= 2 (count dirs))
         (doseq [dir dirs]
           (should (.exists (File. dir)))
-          ;; Should have symlink to deps.edn
-          (should (Files/isSymbolicLink (.toPath (File. (str dir "/deps.edn")))))
+          ;; Should have a copy of the project config (not a symlink)
+          (let [config (if (.exists (File. "bb.edn")) "bb.edn" "deps.edn")]
+            (should (.exists (File. (str dir "/" config))))
+            (should-not (Files/isSymbolicLink (.toPath (File. (str dir "/" config))))))
           ;; Should have source file with original content
           (should= original-content (slurp (str dir "/" source-rel))))
         (finally
@@ -41,43 +43,51 @@
         (finally
           (workers/cleanup-worker-dirs! base-dir)))))
 
-  (it "symlinks .cpcache/ if it exists"
-    (let [base-dir "target/test-workers-cpcache"
+  (it "does not symlink cache directories (cached classpaths would bypass source overlay)"
+    (let [base-dir "target/test-workers-cache"
           source-rel "src/myapp/foo.cljc"
           content "(ns myapp.foo)\n"
-          cpcache-dir (File. ".cpcache")]
-      (let [dirs (workers/create-worker-dirs! base-dir source-rel content 1)]
-        (try
-          (let [cp-link (File. (str (first dirs) "/.cpcache"))]
-            (if (.exists cpcache-dir)
-              (should (Files/isSymbolicLink (.toPath cp-link)))
-              (should-not (.exists cp-link))))
-          (finally
-            (workers/cleanup-worker-dirs! base-dir))))))
-
-  (it "creates source overlay with symlinked siblings"
-    (let [base-dir "target/test-workers-overlay"
-          source-rel "src/clj_mutate/core.cljc"
-          content "(ns clj-mutate.core)\n"
           dirs (workers/create-worker-dirs! base-dir source-rel content 1)]
       (try
-        (let [dir (first dirs)
-              src-dir (File. (str dir "/src"))]
-          ;; src/ should be a real directory, not a symlink
-          (should (.isDirectory src-dir))
-          (should-not (Files/isSymbolicLink (.toPath src-dir)))
-          ;; The mutated file should be a real file
-          (should (.isFile (File. (str dir "/" source-rel))))
-          (should-not (Files/isSymbolicLink (.toPath (File. (str dir "/" source-rel)))))
-          (should= content (slurp (str dir "/" source-rel)))
-          ;; Sibling source files should be symlinks
-          (let [siblings (.listFiles (File. (str dir "/src/clj_mutate")))
-                non-mutated (filter #(not= "core.cljc" (.getName %)) siblings)]
-            (should (pos? (count non-mutated)))
-            (doseq [s non-mutated]
-              (should (Files/isSymbolicLink (.toPath s))))))
+        (let [dir (first dirs)]
+          (should-not (.exists (File. (str dir "/.cpcache"))))
+          (should-not (.exists (File. (str dir "/.babashka")))))
         (finally
-          (workers/cleanup-worker-dirs! base-dir))))))
+          (workers/cleanup-worker-dirs! base-dir)))))
+
+  (it "creates source overlay with symlinked siblings"
+    ;; Use a temp directory as the project root to avoid writing through
+    ;; symlinks to real project files during mutation testing
+    (let [base-dir "target/test-workers-overlay"
+          temp-root (str "target/test-overlay-root-" (System/nanoTime))
+          source-rel "src/myns/target.cljc"
+          content "(ns myns.target)\n"]
+      ;; Create a fake project source tree
+      (.mkdirs (File. (str temp-root "/src/myns")))
+      (spit (str temp-root "/src/myns/target.cljc") "(ns myns.target :original)")
+      (spit (str temp-root "/src/myns/sibling_a.cljc") "(ns myns.sibling-a)")
+      (spit (str temp-root "/src/myns/sibling_b.cljc") "(ns myns.sibling-b)")
+      (try
+        (let [worker-path (str base-dir "/worker-0")]
+          (.mkdirs (File. worker-path))
+          (#'workers/setup-source-overlay! worker-path temp-root source-rel content)
+          (let [src-dir (File. (str worker-path "/src"))]
+            ;; src/ should be a real directory, not a symlink
+            (should (.isDirectory src-dir))
+            (should-not (Files/isSymbolicLink (.toPath src-dir)))
+            ;; The target file should be a real file with overlay content
+            (should (.isFile (File. (str worker-path "/" source-rel))))
+            (should-not (Files/isSymbolicLink (.toPath (File. (str worker-path "/" source-rel)))))
+            (should= content (slurp (str worker-path "/" source-rel)))
+            ;; Sibling source files should be symlinks
+            (let [siblings (.listFiles (File. (str worker-path "/src/myns")))
+                  non-target (filter #(not= "target.cljc" (.getName %)) siblings)]
+              (should= 2 (count non-target))
+              (doseq [s non-target]
+                (should (Files/isSymbolicLink (.toPath s)))))))
+        (finally
+          (workers/cleanup-worker-dirs! base-dir)
+          (#'workers/delete-recursive! (File. temp-root)))))))
 
 (describe "cleanup-worker-dirs!"
   (it "removes the base directory and all contents"

--- a/src/clj_mutate/core.cljc
+++ b/src/clj_mutate/core.cljc
@@ -332,11 +332,8 @@
            (when-not lines (print-uncovered uncovered))
            (save-backup! source-path analysis-content)
             (try
-              (let [run-fn (if (project/bb-project?)
-                             run-mutations-serial
-                             run-mutations-parallel)
-                    results (run-fn sites source-path
-                                    analysis-content timeout-ms)
+               (let [results (run-mutations-parallel sites source-path
+                                                      analysis-content timeout-ms)
                    killed (count (filter #(= :killed (:result %)) results))
                    total (count results)
                    pct (if (zero? total) 0.0 (* 100.0 (/ killed total)))

--- a/src/clj_mutate/core.cljc
+++ b/src/clj_mutate/core.cljc
@@ -224,7 +224,7 @@
         worker-dirs (workers/create-worker-dirs!
                       run-base-dir source-path original-content n-workers)
         queue (java.util.concurrent.LinkedBlockingQueue. ^java.util.Collection (vec sites))
-        results (java.util.concurrent.ConcurrentLinkedQueue.)
+        results (atom [])
         counter (atom 0)
         total (count sites)
         lock (Object.)
@@ -236,14 +236,14 @@
                           (let [r (mutate-and-test-in-dir dir source-path
                                                           original-content site timeout-ms)
                                 n (swap! counter inc)]
-                            (.add results r)
+                            (swap! results conj r)
                             (locking lock
                               (print-progress (dec n) total r site))
                             (recur))))))
                   worker-dirs)]
     (try
       (run! deref futures)
-      (vec (sort-by #(:index (:site %)) results))
+      (vec (sort-by #(:index (:site %)) @results))
       (finally
         (workers/cleanup-worker-dirs! run-base-dir)))))
 

--- a/src/clj_mutate/core.cljc
+++ b/src/clj_mutate/core.cljc
@@ -4,6 +4,7 @@
             [clojure.tools.reader.reader-types :as reader-types]
             [clj-mutate.coverage :as coverage]
             [clj-mutate.mutations :as mutations]
+            [clj-mutate.project :as project]
             [clj-mutate.runner :as runner]
             [clj-mutate.workers :as workers])
   (:import [java.io File]))
@@ -195,7 +196,9 @@
   [args]
   (cond
     (empty? args)
-    {:error "Usage: clj -M:mutate <source-file.cljc> [--lines L1,L2,...]"}
+    {:error (str "Usage: "
+                 (if (project/bb-project?) "bb mutate" "clj -M:mutate")
+                 " <source-file.cljc> [--lines L1,L2,...]")}
 
     (not (.exists (File. (first args))))
     {:error (str "Source file not found: " (first args))}

--- a/src/clj_mutate/core.cljc
+++ b/src/clj_mutate/core.cljc
@@ -214,6 +214,18 @@
                    (:description site)))
   (flush))
 
+(defn run-mutations-serial
+  "Run all mutation sites sequentially.
+   Returns results sorted by site index."
+  [sites source-path original-content timeout-ms]
+  (vec
+    (map-indexed
+      (fn [i site]
+        (let [r (mutate-and-test source-path original-content nil site timeout-ms)]
+          (print-progress i (count sites) r site)
+          r))
+      sites)))
+
 (defn run-mutations-parallel
   "Run all mutation sites in parallel using worker directories.
    Returns results sorted by site index."
@@ -231,15 +243,19 @@
         futures (mapv
                   (fn [dir]
                     (future
-                      (loop []
-                        (when-let [site (.poll queue)]
-                          (let [r (mutate-and-test-in-dir dir source-path
-                                                          original-content site timeout-ms)
-                                n (swap! counter inc)]
-                            (swap! results conj r)
-                            (locking lock
-                              (print-progress (dec n) total r site))
-                            (recur))))))
+                      (try
+                        (loop []
+                          (when-let [site (.poll queue)]
+                            (let [r (mutate-and-test-in-dir dir source-path
+                                                            original-content site timeout-ms)
+                                  n (swap! counter inc)]
+                              (swap! results conj r)
+                              (locking lock
+                                (print-progress (dec n) total r site))
+                              (recur))))
+                        (catch Exception e
+                          (locking lock
+                            (println (str "Worker error: " (.getMessage e))))))))
                   worker-dirs)]
     (try
       (run! deref futures)
@@ -313,9 +329,12 @@
                             (/ elapsed-ms 1000.0) (/ timeout-ms 1000.0)))
            (when-not lines (print-uncovered uncovered))
            (save-backup! source-path analysis-content)
-           (try
-             (let [results (run-mutations-parallel sites source-path
-                                                    analysis-content timeout-ms)
+            (try
+              (let [run-fn (if (project/bb-project?)
+                             run-mutations-serial
+                             run-mutations-parallel)
+                    results (run-fn sites source-path
+                                    analysis-content timeout-ms)
                    killed (count (filter #(= :killed (:result %)) results))
                    total (count results)
                    pct (if (zero? total) 0.0 (* 100.0 (/ killed total)))

--- a/src/clj_mutate/core.cljc
+++ b/src/clj_mutate/core.cljc
@@ -105,23 +105,25 @@
 
 (defn mutate-source-text
   "Replace a single token in the original source text, preserving formatting.
-   Uses :line and :column from the mutation site to target the right occurrence."
+   Uses :line and :column from the mutation site to target the right occurrence.
+   Falls back to global first-match when :line is nil."
   [original-content site]
-  (let [lines (str/split original-content #"\n" -1)
-        line-idx (dec (:line site))
-        line (nth lines line-idx)
-        pat (token-pattern (:original site))
-        col (:column site)
-        replaced (if col
-                   (let [search-start (max 0 (- col 2))
-                         prefix (subs line 0 search-start)
-                         suffix (subs line search-start)
-                         new-suffix (str/replace-first suffix pat (str (:mutant site)))]
-                     (str prefix new-suffix))
-                   (str/replace-first line pat (str (:mutant site))))
-        new-lines (assoc lines line-idx replaced)
-        result (str/join "\n" new-lines)]
-    result))
+  (let [pat (token-pattern (:original site))]
+    (if-let [line-num (:line site)]
+      (let [lines (str/split original-content #"\n" -1)
+            line-idx (dec line-num)
+            line (nth lines line-idx)
+            col (:column site)
+            replaced (if col
+                       (let [search-start (max 0 (- col 2))
+                             prefix (subs line 0 search-start)
+                             suffix (subs line search-start)
+                             new-suffix (str/replace-first suffix pat (str (:mutant site)))]
+                         (str prefix new-suffix))
+                       (str/replace-first line pat (str (:mutant site))))
+            new-lines (assoc lines line-idx replaced)]
+        (str/join "\n" new-lines))
+      (str/replace-first original-content pat (str (:mutant site))))))
 
 (defn mutate-and-test
   "Apply one mutation, write file, run all specs, restore original.

--- a/src/clj_mutate/coverage.cljc
+++ b/src/clj_mutate/coverage.cljc
@@ -1,6 +1,7 @@
 (ns clj-mutate.coverage
   (:require [clojure.string :as str]
-            [clojure.java.shell :as shell])
+            [clojure.java.shell :as shell]
+            [clj-mutate.project :as project])
   (:import [java.io File]))
 
 (defn parse-lcov
@@ -73,15 +74,21 @@
     :else nil))
 
 (defn load-coverage
-  "Orchestrator: run coverage if lcov.info missing/stale, parse, return covered lines."
+  "Orchestrator: run coverage if lcov.info missing/stale, parse, return covered lines.
+   For babashka projects, Cloverage is not available so coverage is only used
+   if an lcov.info file already exists."
   [source-path]
   (let [lcov-file (File. (lcov-path))]
-    (when-let [reason (stale-reason lcov-file source-path)]
-      (println
-        (case reason
-          :missing "Coverage file missing; regenerating LCOV with clj -M:cov --lcov."
-          :stale "Coverage file is stale; regenerating LCOV with clj -M:cov --lcov."))
-      (when-not (run-coverage!)
-        (println "Coverage refresh failed; continuing with existing coverage if available.")))
-    (when (.exists lcov-file)
-      (covered-lines (parse-lcov (slurp lcov-file)) source-path))))
+    (if (project/bb-project?)
+      (when (.exists lcov-file)
+        (covered-lines (parse-lcov (slurp lcov-file)) source-path))
+      (do
+        (when-let [reason (stale-reason lcov-file source-path)]
+          (println
+            (case reason
+              :missing "Coverage file missing; regenerating LCOV with clj -M:cov --lcov."
+              :stale "Coverage file is stale; regenerating LCOV with clj -M:cov --lcov."))
+          (when-not (run-coverage!)
+            (println "Coverage refresh failed; continuing with existing coverage if available.")))
+        (when (.exists lcov-file)
+          (covered-lines (parse-lcov (slurp lcov-file)) source-path))))))

--- a/src/clj_mutate/project.cljc
+++ b/src/clj_mutate/project.cljc
@@ -1,0 +1,23 @@
+(ns clj-mutate.project
+  (:import [java.io File]))
+
+(defn bb-project?
+  "True if the current working directory has a bb.edn file."
+  ([] (bb-project? (System/getProperty "user.dir")))
+  ([dir] (.exists (File. (str dir "/bb.edn")))))
+
+(defn spec-command
+  "Return the command vector for running specs."
+  ([] (spec-command (System/getProperty "user.dir")))
+  ([dir]
+   (if (bb-project? dir)
+     ["bb" "spec"]
+     ["clj" "-M:spec"])))
+
+(defn config-file
+  "Return the project config filename (bb.edn or deps.edn)."
+  ([] (config-file (System/getProperty "user.dir")))
+  ([dir]
+   (if (bb-project? dir)
+     "bb.edn"
+     "deps.edn")))

--- a/src/clj_mutate/runner.cljc
+++ b/src/clj_mutate/runner.cljc
@@ -1,16 +1,19 @@
 ;; mutation-tested: 2026-02-27
 (ns clj-mutate.runner
+  (:require [clj-mutate.project :as project])
   (:import [java.util.concurrent TimeUnit]))
 
 (defn run-specs
-  "Run all specs via clj -M:spec. Returns :killed, :survived, or :timeout.
+  "Run all specs. Returns :killed, :survived, or :timeout.
+   Uses bb or clj depending on project type.
    Optional timeout-ms: kill process after this many milliseconds.
    Optional dir: run specs in the given directory.
    A timeout indicates an infinite loop — treated as :killed by caller."
   ([] (run-specs nil nil))
   ([timeout-ms] (run-specs timeout-ms nil))
   ([timeout-ms dir]
-   (let [pb (doto (ProcessBuilder. ^java.util.List ["clj" "-M:spec"])
+   (let [cmd (project/spec-command (or dir (System/getProperty "user.dir")))
+         pb (doto (ProcessBuilder. ^java.util.List cmd)
               (.redirectErrorStream true))
          _ (when dir (.directory pb (java.io.File. dir)))
          process (.start pb)

--- a/src/clj_mutate/workers.cljc
+++ b/src/clj_mutate/workers.cljc
@@ -1,4 +1,5 @@
 (ns clj-mutate.workers
+  (:require [clj-mutate.project :as project])
   (:import [java.io File]
            [java.util UUID]
            [java.nio.file Files Paths]))
@@ -25,23 +26,29 @@
 
 (defn create-worker-dirs!
   "Create n worker directories under base-dir. Each gets symlinks to
-   deps.edn, spec/, .cpcache/ (if present), and a real copy of the
-   source file at source-rel-path."
+   the project config (bb.edn or deps.edn), spec/, cache dirs, and a
+   real copy of the source file at source-rel-path."
   [base-dir source-rel-path original-content n]
-  (let [project-root (System/getProperty "user.dir")]
+  (let [project-root (System/getProperty "user.dir")
+        config (project/config-file project-root)
+        bb? (project/bb-project? project-root)]
     (vec
       (for [i (range n)]
         (let [dir-path (str base-dir "/worker-" i)
               dir (File. dir-path)
               source-file (File. dir source-rel-path)]
           (.mkdirs (.getParentFile source-file))
-          (symlink! (str dir-path "/deps.edn")
-                    (str project-root "/deps.edn"))
+          (symlink! (str dir-path "/" config)
+                    (str project-root "/" config))
           (symlink! (str dir-path "/spec")
                     (str project-root "/spec"))
-          (when (.exists (File. (str project-root "/.cpcache")))
-            (symlink! (str dir-path "/.cpcache")
-                      (str project-root "/.cpcache")))
+          (if bb?
+            (when (.exists (File. (str project-root "/.babashka")))
+              (symlink! (str dir-path "/.babashka")
+                        (str project-root "/.babashka")))
+            (when (.exists (File. (str project-root "/.cpcache")))
+              (symlink! (str dir-path "/.cpcache")
+                        (str project-root "/.cpcache"))))
           (spit (.getPath source-file) original-content)
           dir-path)))))
 

--- a/src/clj_mutate/workers.cljc
+++ b/src/clj_mutate/workers.cljc
@@ -1,3 +1,4 @@
+;; mutation-tested: 2026-03-25
 (ns clj-mutate.workers
   (:require [clj-mutate.project :as project])
   (:import [java.io File]
@@ -65,17 +66,10 @@
       (for [i (range n)]
         (let [dir-path (str base-dir "/worker-" i)]
           (.mkdirs (File. dir-path))
-          (symlink! (str dir-path "/" config)
-                    (str project-root "/" config))
+          (spit (str dir-path "/" config)
+                (slurp (str project-root "/" config)))
           (symlink! (str dir-path "/spec")
                     (str project-root "/spec"))
-          (if bb?
-            (when (.exists (File. (str project-root "/.babashka")))
-              (symlink! (str dir-path "/.babashka")
-                        (str project-root "/.babashka")))
-            (when (.exists (File. (str project-root "/.cpcache")))
-              (symlink! (str dir-path "/.cpcache")
-                        (str project-root "/.cpcache"))))
           (setup-source-overlay! dir-path project-root
                                   source-rel-path original-content)
           dir-path)))))

--- a/src/clj_mutate/workers.cljc
+++ b/src/clj_mutate/workers.cljc
@@ -24,20 +24,47 @@
           (delete-recursive! child))))
     (.delete f)))
 
+(defn- setup-source-overlay!
+  "Create a source tree overlay in the worker directory. The first
+   segment of source-rel-path (e.g. \"src\") becomes a real directory
+   in the worker. From there, each directory level along the path to
+   the mutated file is a real directory with symlinks to siblings.
+   The mutated file itself is a real file; everything else in the
+   source tree is a symlink back to the original project."
+  [worker-path project-root source-rel-path original-content]
+  (let [segments (clojure.string/split source-rel-path #"/")
+        source-file (File. worker-path source-rel-path)]
+    (.mkdirs (.getParentFile source-file))
+    ;; Start from the first segment (e.g. "src"), symlink siblings
+    ;; at each directory level down to the mutated file
+    (loop [depth 0 rel-path (first segments)]
+      (let [next-depth (inc depth)]
+        (when (< next-depth (count segments))
+          (let [next-segment (nth segments next-depth)
+                abs-dir (str project-root "/" rel-path)
+                worker-dir (str worker-path "/" rel-path)
+                real-dir (File. abs-dir)]
+            (when (.isDirectory real-dir)
+              (doseq [child (.listFiles real-dir)]
+                (let [child-name (.getName child)]
+                  (when (not= child-name next-segment)
+                    (symlink! (str worker-dir "/" child-name)
+                              (.getPath child))))))
+            (recur next-depth (str rel-path "/" next-segment))))))
+    (spit (.getPath source-file) original-content)))
+
 (defn create-worker-dirs!
   "Create n worker directories under base-dir. Each gets symlinks to
    the project config (bb.edn or deps.edn), spec/, cache dirs, and a
-   real copy of the source file at source-rel-path."
+   source tree overlay where only the mutated file is a real file."
   [base-dir source-rel-path original-content n]
   (let [project-root (System/getProperty "user.dir")
         config (project/config-file project-root)
         bb? (project/bb-project? project-root)]
     (vec
       (for [i (range n)]
-        (let [dir-path (str base-dir "/worker-" i)
-              dir (File. dir-path)
-              source-file (File. dir source-rel-path)]
-          (.mkdirs (.getParentFile source-file))
+        (let [dir-path (str base-dir "/worker-" i)]
+          (.mkdirs (File. dir-path))
           (symlink! (str dir-path "/" config)
                     (str project-root "/" config))
           (symlink! (str dir-path "/spec")
@@ -49,7 +76,8 @@
             (when (.exists (File. (str project-root "/.cpcache")))
               (symlink! (str dir-path "/.cpcache")
                         (str project-root "/.cpcache"))))
-          (spit (.getPath source-file) original-content)
+          (setup-source-overlay! dir-path project-root
+                                  source-rel-path original-content)
           dir-path)))))
 
 (defn cleanup-worker-dirs!


### PR DESCRIPTION
babashka projects can use the skill without needing a deps.edn
Update speclj 3.12.1
Significantly faster in babashka.  Sample run:
```
Wall clock
bb	4.3s
clj	65.8s
bb is ~15x faster wall clock. Similar total CPU time (~32-34s user), but bb parallelizes much more aggressively (1052% CPU vs 75%). The JVM startup cost per mutation run is the killer — bb's fast startup means each of the 52 mutations runs almost instantly.
```